### PR TITLE
do not rely on JSON.parse + JSON.serialize for spacer/pretty print

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,7 @@ node_js:
   - '0.12'
   - '4'
   - '5'
-  - 'stable'
+  - '6'
 
 before_install:
   - npm install mocha browserify
-
-script:
-  - npm run unit
-  - npm run lint
-  - npm run bundle

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@ CONTRIBUTING
 
 JSON8 is written in ES5, tests are written in ES6.
 
-1. ```npm install mocha browserify -g```
+1. ```npm install mocha browserify```
 2. Edit the files, make sure to comply with the code style and quality.
 3. Add unit tests covering your modifications.
 4. ```npm test``` to run unit tests and check syntax.

--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ oo.isPrimitive(42)       // true
 
 oo.isPrimitive([]])      // false
 oo.isPrimitive({})       // false
+oo.isPrimitive(undefined)// false
 oo.isPrimitive(Infinity) // false
 oo.isPrimitive(NaN)      // false
 ```
@@ -640,7 +641,7 @@ oo.serialize(-0)   // "-0"
 # Tests
 
 ```
-npm install -g mocha browserify
+npm install mocha browserify
 npm test
 ```
 

--- a/lib/serialize.js
+++ b/lib/serialize.js
@@ -15,7 +15,7 @@ if (global.Map && Map.prototype.toJSON)
 if (global.Set && Set.prototype.toJSON)
   delete Set.prototype.toJSON
 
-function stringify(obj, opts) {
+function stringify(obj, opts, depth) {
   if (opts.toJSON === true && typeof obj === OBJECT && obj !== null && typeof obj.toJSON === 'function')
     obj = obj.toJSON()
 
@@ -37,11 +37,21 @@ function stringify(obj, opts) {
   if (obj === null)
     return 'null'
 
+  var space = ''
+  for (var y = 0; y < depth; y++) {
+    space += opts.space
+  }
+  var prevspace = ''
+  for (var x = 0; x < depth - 1; x++) {
+    prevspace += opts.space
+  }
+
   var replacer = opts.replacer
   var str = ''
 
   if (Array.isArray(obj)) {
     str += '['
+
     for (var i = 0, l = obj.length; i < l; i++) {
       var item = obj[i]
       if (replacer) {
@@ -51,13 +61,17 @@ function stringify(obj, opts) {
           continue
         }
       }
-      str += stringify(item, opts)
-      if (i !== l - 1) str += ','
+      if (space && str[str.length - 1] !== '\n') str += '\n'
+      str += space + stringify(item, opts, depth + 1)
+      if (i !== l - 1) str += ',' + (space ? '\n' : '')
+      else if (space) str+= '\n' + prevspace
     }
+
     str += ']'
   }
   else if (global.Set && obj instanceof Set) {
     str += '['
+
     var n = 0
     obj.forEach(function(setItem) {
       if (replacer) {
@@ -68,13 +82,17 @@ function stringify(obj, opts) {
           return
         }
       }
-      str += stringify(setItem, opts)
-      if (n++ !== obj.size - 1) str += ','
+      if (space && n === 0) str += '\n'
+      str += stringify(setItem, opts, depth + 1)
+      if (n++ !== obj.size - 1) str += ',' + (space ? '\n' : '')
+      else if (space) str += '\n' + prevspace
     })
+
     str += ']'
   }
   else if (global.Map && obj instanceof Map) {
     str += '{'
+
     var m = 0
     obj.forEach(function(v, k) {
       if (typeof k !== STRING)
@@ -88,14 +106,18 @@ function stringify(obj, opts) {
           return
         }
       }
-      str += JSON.stringify(k) + ':' + stringify(v, opts)
+      if (space && m === 0) str += '\n'
+      str += JSON.stringify(k) + ':' + (space ? '\n' : '') + stringify(v, opts, depth + 1)
       if (m++ !== obj.size - 1) str += ','
+      else if (space) str += '\n' + prevspace
     })
+
     str += '}'
   }
   else if (type === OBJECT) {
     str += '{'
     var keys = Object.keys(obj)
+
     for (var j = 0, len = keys.length; j < len; j++) {
       var k = keys[j]
       var v = obj[k]
@@ -108,9 +130,15 @@ function stringify(obj, opts) {
           continue
         }
       }
-      str += JSON.stringify(k) + ':' + stringify(v, opts)
-      if (j !== len - 1) str += ','
+      if (space && str[str.length - 1] !== '\n') str+='\n'
+      str += space + JSON.stringify(k) + ':' + (space ? ' ' : '') + stringify(v, opts, depth + 1)
+      if (j !== len - 1) { // FIXME
+        str += ','
+        if (space) str += '\n'
+      }
+      else if (space) str += '\n' + prevspace
     }
+
     str += '}'
   }
   else {
@@ -126,9 +154,14 @@ module.exports = function serialize(obj, options) {
   opts.toJSON = options.toJSON !== false
   opts.replacer = typeof options.replacer === 'function' && options.replacer
 
-  var string = stringify(obj, opts)
-  var tspace = typeof options.space
-  if (tspace === 'string' || tspace === 'number')
-    string = JSON.stringify(JSON.parse(string), null, options.space)
-  return string
+  opts.space = ''
+  if (typeof options.space === 'number' && options.space >= 1) {
+    for (var i = 0; i < options.space; i++) {
+      opts.space += ' '
+    }
+  } else if (typeof options.space === 'string') {
+    opts.space = options.space
+  }
+
+  return stringify(obj, opts, 1)
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,11 @@
   "version": "0.8.2",
   "description": "JSON toolkit for JavaScript",
   "keywords": [
-    "JSON"
+    "JSON",
+    "es6",
+    "es2015",
+    "map",
+    "set"
   ],
   "homepage": "https://github.com/JSON8/JSON8",
   "repository": "github:JSON8/JSON8",
@@ -20,9 +24,9 @@
   "author": "Sonny Piers <sonny@fastmail.net>",
   "license": "ISC",
   "devDependencies": {
-    "babel-preset-es2015": "^6.3.13",
+    "babel-preset-es2015": "^6.6.0",
     "babel-register": "^6.5.1",
-    "es6-collections": "^0.5.5",
+    "es6-collections": "^0.5.6",
     "eslint": "^1.10.3",
     "eslint-config-atlas": "^1.0.2",
     "eslint-config-bestpratices": "^1.0.7"

--- a/test/serialize.js
+++ b/test/serialize.js
@@ -127,12 +127,13 @@ describe('serialize', () => {
 
     it('serializes equally to it with space param as number', () => {
       assert.strictEqual(serialize(obj, {space: 2}), JSON.stringify(obj, null, 2))
+      assert.strictEqual(serialize(obj, {space: 2}), JSON.stringify(obj, null, '  '))
     })
 
     it('serializes equally to it with space param as string', () => {
       assert.strictEqual(serialize(obj, {space: '    '}), JSON.stringify(obj, null, '    '))
+      assert.strictEqual(serialize(obj, {space: '    '}), JSON.stringify(obj, null, 4))
     })
-
   })
 
   describe('replacer option', () => {
@@ -211,6 +212,34 @@ describe('serialize', () => {
         return v
       }
       assert.strictEqual(serialize(set, {replacer}), '["foo","baz"]')
+    })
+
+    describe('with space option', () => {
+      it('object', () => {
+        const replacer = () => undefined
+        const s = serialize({foo: 'bar'}, {replacer, space: 2})
+        assert.strictEqual(s, '{}')
+      })
+
+      it('array', () => {
+        const replacer = () => undefined
+        const s = serialize(['foo'], {replacer, space: 2})
+        assert.strictEqual(s, '[]')
+      })
+
+      it('set', () => {
+        const replacer = () => undefined
+        const s = serialize(new Set(['foo']), {replacer, space: 2})
+        assert.strictEqual(s, '[]')
+      })
+
+      it('map', () => {
+        const replacer = () => undefined
+        const map = new Map()
+        map.set('foo', 'bar')
+        const s = serialize(map, {replacer, space: 2})
+        assert.strictEqual(s, '{}')
+      })
     })
 
     // https://github.com/JSON8/JSON8/issues/18


### PR DESCRIPTION
# why

Should be significantly faster and provides more granularity for future options

(I want the ability to define a max-depth so that JSON Patch operations can be pretty-printed as one line)

# todo 

~~check case where a replacer return undefined (as that value won't be included), it probably fails if only one value for structures and other edge cases~~ done

# next

add max depth for spacing